### PR TITLE
Fixed file input

### DIFF
--- a/app/templates/pod_finder/index.html
+++ b/app/templates/pod_finder/index.html
@@ -65,9 +65,14 @@
             <p>A friend sent you their pod? Add it to your pear! The file you input should either be in .csv or .png format.</p>
             <form method="POST"  accept-charset="UTF-8" enctype="multipart/form-data" action="{{url_for('pod_finder.subscribe_from_file')}}">
                 <div class="input-group">
-                     <input id="file_source" name="file_source" type="file" class="btn btn-default btn-s">
+                     <input id="file_source" accept=".csv" oninput="invert()" name="file_source" type="file" class="btn btn-default btn-s">
                      <span class="input-group-btn">
-                     <input id="submit_button" type="submit" class="btn btn-primary" value="Read file" style="width:100px !important">
+                     <input id="submit_button_input" disabled="true" type="submit" class="btn btn-primary" value="Read file" style="width:100px !important">
+                     <script>
+                       function invert(){
+                         document.getElementById("submit_button_input").disabled=false
+                       }
+                     </script>
                      </span>
                 </div>
             </form>


### PR DESCRIPTION
This is the fix for the issue raised by me with id #17.
Basically, this disables the "Read File" button, unless the user provides a proper file with ".csv" extension.