### PR TITLE
Make the URL list and pod list editable in DB admin + some basic cleanup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -112,3 +112,6 @@ app.db
 pods/
 urls_to_index.txt
 pods_to_index.txt
+
+
+app/static/webmap/

--- a/app/__init__.py
+++ b/app/__init__.py
@@ -1,9 +1,21 @@
+# import logging 
+import logging
+
 # Import flask and template operators
 from flask import Flask, render_template
 from flask_admin import Admin
 
 # Import SQLAlchemy
 from flask_sqlalchemy import SQLAlchemy
+
+
+def configure_logging():
+    # register root logging
+    logging.basicConfig(level=logging.DEBUG)
+    logging.getLogger('werkzeug').setLevel(logging.INFO)
+
+
+configure_logging()
 
 # Define the WSGI application object
 app = Flask(__name__)
@@ -15,10 +27,6 @@ app.config.from_object('config')
 # by modules and controllers
 db = SQLAlchemy(app)
 
-# Sample HTTP error handling
-#@app.errorhandler(404)
-#def not_found(error):
-#    return render_template('404.html'), 404
 
 # Import a module / component using its blueprint handler variable (mod_auth)
 from app.indexer.controllers import indexer as indexer_module

--- a/app/__init__.py
+++ b/app/__init__.py
@@ -62,15 +62,43 @@ class UrlsModelView(ModelView):
     column_exclude_list = ['vector','freqs']
     column_searchable_list = ['url', 'title', 'keyword', 'pod']
     column_editable_list = ['keyword']
-    can_edit = False
+    can_edit = True
     page_size = 50
+    form_widget_args = {
+        'vector': {
+            'readonly': True
+        },
+        'freqs': {
+            'readonly': True
+        },
+        'date_created': {
+            'readonly': True
+        },
+        'date_modified': {
+            'readonly': True
+        },
+    }
 
 class PodsModelView(ModelView):
     list_template = 'admin/pears_list.html'
     column_exclude_list = ['DS_vector','word_vector']
     column_searchable_list = ['url', 'name', 'description', 'language']
-    can_edit = False
+    can_edit = True
     page_size = 50
+    form_widget_args = {
+        'DS_vector': {
+            'readonly': True
+        },
+        'word_vector': {
+            'readonly': True
+        },
+        'date_created': {
+            'readonly': True
+        },
+        'date_modified': {
+            'readonly': True
+        },
+    }
 
 admin.add_view(PodsModelView(Pods, db.session))
 admin.add_view(UrlsModelView(Urls, db.session))

--- a/app/search/controllers.py
+++ b/app/search/controllers.py
@@ -1,5 +1,6 @@
 # Import flask dependencies
 from flask import Blueprint, request, render_template, send_from_directory
+from flask import current_app
 
 # Import the database object from the main app module
 from app.api.models import Urls
@@ -7,38 +8,27 @@ from app.search import score_pages
 
 # Import utilities
 import re
+import logging
+
+
+LOG = logging.getLogger(__name__)
 
 # Define the blueprint:
 search = Blueprint('search', __name__, url_prefix='')
 
 
-def get_cached_urls(urls):
-    urls_with_cache = urls
-    for u in urls_with_cache:
-        cache = re.sub(r"http\:\/\/|https\:\/\/", "", u[0])
-        if cache[-5:] != ".html":
-            cache += ".html"
-        print(cache)
-        u.append(cache)
-    return urls_with_cache
-
-
 @search.route('/')
 @search.route('/index')
-def index():
-    '''Check whether DS has been updated.'''
-    # if DS_M.shape[0] != len(Urls.query.all()):
-    #    mk_matrix_from_db()
+def index():  
     results = []
     internal_message = ""
-    if len(Urls.query.all()) == 0:
+    if Urls.query.count() == 0:
         internal_message = "Hey there! It looks like you're here\
          for the first time :) To understand how to use PeARS,\
          go to the FAQ (link at the top of the page)."
     query = request.args.get('q')
-    print(request, request.args, query)
     if not query:
-        print("no query")
+        LOG.info("No Querry")
         return render_template(
             "search/index.html",
             internal_message=internal_message)
@@ -51,7 +41,6 @@ def index():
             pears = ['no pear found :(']
             score_pages.ddg_redirect(query)
 
-        # results = get_cached_urls(results)
         return render_template(
             'search/results.html', pears=pods, query=query, results=results)
 


### PR DESCRIPTION
Currently, the URL list and pod list is not editable from the DB admin, we can only delete it.
    This commit enables the user to edit basic fields of these lists.
    - vector, freqs, date_created, date_modified fields of the URL Model are not editable
    - DS_vector, Word_vector, date_created, date_modified fields of the PODs Model are not editable

other than this
- Added logger to search/controllers
- Removed some unused & commented code.