### PR TITLE
License fixes

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -39,6 +39,7 @@ from app.search.controllers import search as search_module
 from app.pod_finder.controllers import pod_finder as pod_finder_module
 from app.orchard.controllers import orchard as orchard_module
 from app.pages.controllers import pages as pages_module
+from app.settings.controllers import settings as settings_module
 
 # Register blueprint(s)
 app.register_blueprint(indexer_module)
@@ -47,6 +48,7 @@ app.register_blueprint(search_module)
 app.register_blueprint(pod_finder_module)
 app.register_blueprint(orchard_module)
 app.register_blueprint(pages_module)
+app.register_blueprint(settings_module)
 # ..
 
 # Build the database:

--- a/app/api/__init__.py
+++ b/app/api/__init__.py
@@ -1,5 +1,3 @@
-# SPDX-FileCopyrightText: 2022 Aurelie Herbelot, <aurelie.herbelot@unitn.it>, 
+# SPDX-FileCopyrightText: 2022 PeARS Project, <community@pearsproject.org>, 
 #
 # SPDX-License-Identifier: AGPL-3.0-only
-
-#import app.api.mk_urls_csv

--- a/app/api/controllers.py
+++ b/app/api/controllers.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2022 Aurelie Herbelot, <aurelie.herbelot@unitn.it>, 
+# SPDX-FileCopyrightText: 2022 PeARS Project, <community@pearsproject.org>, 
 #
 # SPDX-License-Identifier: AGPL-3.0-only
 

--- a/app/api/fly.py
+++ b/app/api/fly.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2022 Aurelie Herbelot, <aurelie.herbelot@unitn.it>, 
+# SPDX-FileCopyrightText: 2022 PeARS Project, <community@pearsproject.org>, 
 #
 # SPDX-License-Identifier: AGPL-3.0-only
 

--- a/app/api/models.py
+++ b/app/api/models.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2022 Aurelie Herbelot, <aurelie.herbelot@unitn.it>, 
+# SPDX-FileCopyrightText: 2022 PeARS Project, <community@pearsproject.org>, 
 #
 # SPDX-License-Identifier: AGPL-3.0-only
 

--- a/app/indexer/__init__.py
+++ b/app/indexer/__init__.py
@@ -1,3 +1,3 @@
-# SPDX-FileCopyrightText: 2022 Aurelie Herbelot, <aurelie.herbelot@unitn.it>, 
+# SPDX-FileCopyrightText: 2022 PeARS Project, <community@pearsproject.org>, 
 #
 # SPDX-License-Identifier: AGPL-3.0-only

--- a/app/indexer/apply_models.py
+++ b/app/indexer/apply_models.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2022 Aurelie Herbelot, <aurelie.herbelot@unitn.it>, 
+# SPDX-FileCopyrightText: 2022 PeARS Project, <community@pearsproject.org>, 
 #
 # SPDX-License-Identifier: AGPL-3.0-only
 

--- a/app/indexer/caching.py
+++ b/app/indexer/caching.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2022 Aurelie Herbelot, <aurelie.herbelot@unitn.it>, 
+# SPDX-FileCopyrightText: 2022 PeARS Project, <community@pearsproject.org>, 
 #
 # SPDX-License-Identifier: AGPL-3.0-only
 

--- a/app/indexer/controllers.py
+++ b/app/indexer/controllers.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2022 Aurelie Herbelot, <aurelie.herbelot@unitn.it>, 
+# SPDX-FileCopyrightText: 2022 PeARS Project, <community@pearsproject.org>, 
 #
 # SPDX-License-Identifier: AGPL-3.0-only
 

--- a/app/indexer/detect_open.py
+++ b/app/indexer/detect_open.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2022 Aurelie Herbelot, <aurelie.herbelot@unitn.it>, 
+# SPDX-FileCopyrightText: 2022 PeARS Project, <community@pearsproject.org>, 
 #
 # SPDX-License-Identifier: AGPL-3.0-only
 

--- a/app/indexer/fly_utils.py
+++ b/app/indexer/fly_utils.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2022 Aurelie Herbelot, <aurelie.herbelot@unitn.it>, 
+# SPDX-FileCopyrightText: 2022 PeARS Project, <community@pearsproject.org>, 
 #
 # SPDX-License-Identifier: AGPL-3.0-only
 

--- a/app/indexer/forms.py
+++ b/app/indexer/forms.py
@@ -1,3 +1,3 @@
-# SPDX-FileCopyrightText: 2022 Aurelie Herbelot, <aurelie.herbelot@unitn.it>, 
+# SPDX-FileCopyrightText: 2022 PeARS Project, <community@pearsproject.org>, 
 #
 # SPDX-License-Identifier: AGPL-3.0-only

--- a/app/indexer/htmlparser.py
+++ b/app/indexer/htmlparser.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2022 Aurelie Herbelot, <aurelie.herbelot@unitn.it>, 
+# SPDX-FileCopyrightText: 2022 PeARS Project, <community@pearsproject.org>, 
 #
 # SPDX-License-Identifier: AGPL-3.0-only
 

--- a/app/indexer/mk_page_vector.py
+++ b/app/indexer/mk_page_vector.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2022 Aurelie Herbelot, <aurelie.herbelot@unitn.it>, 
+# SPDX-FileCopyrightText: 2022 PeARS Project, <community@pearsproject.org>, 
 #
 # SPDX-License-Identifier: AGPL-3.0-only
 

--- a/app/indexer/models.py
+++ b/app/indexer/models.py
@@ -1,3 +1,3 @@
-# SPDX-FileCopyrightText: 2022 Aurelie Herbelot, <aurelie.herbelot@unitn.it>, 
+# SPDX-FileCopyrightText: 2022 PeARS Project, <community@pearsproject.org>, 
 #
 # SPDX-License-Identifier: AGPL-3.0-only

--- a/app/indexer/neighbours.py
+++ b/app/indexer/neighbours.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2022 Aurelie Herbelot, <aurelie.herbelot@unitn.it>, 
+# SPDX-FileCopyrightText: 2022 PeARS Project, <community@pearsproject.org>, 
 #
 # SPDX-License-Identifier: AGPL-3.0-only
 

--- a/app/indexer/spider.py
+++ b/app/indexer/spider.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2022 Aurelie Herbelot, <aurelie.herbelot@unitn.it>, 
+# SPDX-FileCopyrightText: 2022 PeARS Project, <community@pearsproject.org>, 
 #
 # SPDX-License-Identifier: AGPL-3.0-only
 

--- a/app/indexer/vectorizer.py
+++ b/app/indexer/vectorizer.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2022 Aurelie Herbelot, <aurelie.herbelot@unitn.it>, 
+# SPDX-FileCopyrightText: 2022 PeARS Project, <community@pearsproject.org>, 
 #
 # SPDX-License-Identifier: AGPL-3.0-only
 

--- a/app/orchard/controllers.py
+++ b/app/orchard/controllers.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2022 Aurelie Herbelot, <aurelie.herbelot@unitn.it>, 
+# SPDX-FileCopyrightText: 2022 PeARS Project, <community@pearsproject.org>, 
 #
 # SPDX-License-Identifier: AGPL-3.0-only
 

--- a/app/orchard/mk_urls_file.py
+++ b/app/orchard/mk_urls_file.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2022 Aurelie Herbelot, <aurelie.herbelot@unitn.it>, 
+# SPDX-FileCopyrightText: 2022 PeARS Project, <community@pearsproject.org>, 
 #
 # SPDX-License-Identifier: AGPL-3.0-only
 

--- a/app/pages/controllers.py
+++ b/app/pages/controllers.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2022 Aurelie Herbelot, <aurelie.herbelot@unitn.it>, 
+# SPDX-FileCopyrightText: 2022 PeARS Project, <community@pearsproject.org>, 
 #
 # SPDX-License-Identifier: AGPL-3.0-only
 

--- a/app/pod_finder/controllers.py
+++ b/app/pod_finder/controllers.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2022 Aurelie Herbelot, <aurelie.herbelot@unitn.it>, 
+# SPDX-FileCopyrightText: 2022 PeARS Project, <community@pearsproject.org>, 
 #
 # SPDX-License-Identifier: AGPL-3.0-only
 

--- a/app/pod_finder/download_pod_list.py
+++ b/app/pod_finder/download_pod_list.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2022 Aurelie Herbelot, <aurelie.herbelot@unitn.it>, 
+# SPDX-FileCopyrightText: 2022 PeARS Project, <community@pearsproject.org>, 
 #
 # SPDX-License-Identifier: AGPL-3.0-only
 

--- a/app/pod_finder/index_pod_file.py
+++ b/app/pod_finder/index_pod_file.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2022 Aurelie Herbelot, <aurelie.herbelot@unitn.it>, 
+# SPDX-FileCopyrightText: 2022 PeARS Project, <community@pearsproject.org>, 
 #
 # SPDX-License-Identifier: AGPL-3.0-only
 

--- a/app/pod_finder/score_pods.py
+++ b/app/pod_finder/score_pods.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2022 Aurelie Herbelot, <aurelie.herbelot@unitn.it>, 
+# SPDX-FileCopyrightText: 2022 PeARS Project, <community@pearsproject.org>, 
 #
 # SPDX-License-Identifier: AGPL-3.0-only
 

--- a/app/search/controllers.py
+++ b/app/search/controllers.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2022 Aurelie Herbelot, <aurelie.herbelot@unitn.it>, 
+# SPDX-FileCopyrightText: 2022 PeARS Project, <community@pearsproject.org>, 
 #
 # SPDX-License-Identifier: AGPL-3.0-only
 

--- a/app/search/overlap_calculation.py
+++ b/app/search/overlap_calculation.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2022 Aurelie Herbelot, <aurelie.herbelot@unitn.it>, 
+# SPDX-FileCopyrightText: 2022 PeARS Project, <community@pearsproject.org>, 
 #
 # SPDX-License-Identifier: AGPL-3.0-only
 

--- a/app/search/score_pages.py
+++ b/app/search/score_pages.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2022 Aurelie Herbelot, <aurelie.herbelot@unitn.it>, 
+# SPDX-FileCopyrightText: 2022 PeARS Project, <community@pearsproject.org>, 
 #
 # SPDX-License-Identifier: AGPL-3.0-only
 

--- a/app/search/term_cosine.py
+++ b/app/search/term_cosine.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2022 Aurelie Herbelot, <aurelie.herbelot@unitn.it>, 
+# SPDX-FileCopyrightText: 2022 PeARS Project, <community@pearsproject.org>, 
 #
 # SPDX-License-Identifier: AGPL-3.0-only
 

--- a/app/settings/__init__.py
+++ b/app/settings/__init__.py
@@ -1,3 +1,3 @@
-# SPDX-FileCopyrightText: 2022 Aurelie Herbelot, <aurelie.herbelot@unitn.it>, 
+# SPDX-FileCopyrightText: 2022 PeARS Project, <community@pearsproject.org>, 
 #
 # SPDX-License-Identifier: AGPL-3.0-only

--- a/app/settings/__init__.py
+++ b/app/settings/__init__.py
@@ -1,0 +1,3 @@
+# SPDX-FileCopyrightText: 2022 Aurelie Herbelot, <aurelie.herbelot@unitn.it>, 
+#
+# SPDX-License-Identifier: AGPL-3.0-only

--- a/app/settings/controllers.py
+++ b/app/settings/controllers.py
@@ -1,6 +1,7 @@
-# SPDX-FileCopyrightText: 2022 Aurelie Herbelot, <aurelie.herbelot@unitn.it>, 
+# SPDX-FileCopyrightText: 2022 PeARS Project, <community@pearsproject.org>, 
 #
 # SPDX-License-Identifier: AGPL-3.0-only
+
 
 # Import flask dependencies
 import logging

--- a/app/settings/controllers.py
+++ b/app/settings/controllers.py
@@ -1,0 +1,23 @@
+# SPDX-FileCopyrightText: 2022 Aurelie Herbelot, <aurelie.herbelot@unitn.it>, 
+#
+# SPDX-License-Identifier: AGPL-3.0-only
+
+# Import flask dependencies
+import logging
+
+from flask import (Blueprint,
+                   flash,
+                   request,
+                   render_template,
+                   Response)
+
+
+# Define the blueprint:
+settings = Blueprint('settings', __name__, url_prefix='/settings')
+
+
+# Set the route and accepted methods
+@settings.route("/")
+def index():
+    return render_template("settings/index.html")
+

--- a/app/static/cc.png.license
+++ b/app/static/cc.png.license
@@ -1,3 +1,3 @@
-SPDX-FileCopyrightText: 2022 Aurelie Herbelot, <aurelie.herbelot@unitn.it>, 
+SPDX-FileCopyrightText: 2022 PeARS Project, <community@pearsproject.org>, 
 
 SPDX-License-Identifier: AGPL-3.0-only

--- a/app/static/css/styles.css
+++ b/app/static/css/styles.css
@@ -5,9 +5,61 @@
  */
 
 
+:root {
+    --primary-color: #73b4eb;
+    --secondary-color: black;
+ } 
+
 a {
-  color: rgb(3, 139, 48);
+  color: var(--primary-color);
 }
 a:hover {
-  color: rgb(1, 61, 21);
+  color: var(--secondary-color);
+}
+
+.navbar-light {
+  background-color: var(--primary-color);
+}
+
+.card {
+  --bs-card-border-width: 0px;
+  border-width: 0px 0px 1px 0px;
+}
+
+.alert-success {
+    --bs-alert-color: #636464;
+    --bs-alert-bg: #e9ecef;
+    --bs-alert-border-color: #636464;
+}
+
+.navbar {
+  background-color: var(--primary-color);
+}
+
+.btn-success {
+  --bs-btn-bg: var(--primary-color);
+  --bs-btn-border-color: var(--primary-color);
+  --bs-btn-hover-bg: var(--secondary-color);
+  --bs-btn-hover-border-color: var(--secondary-color);
+}
+
+.submit-color-button {
+  height: 30px;
+  width: 30px;
+  margin: 10px 5px 0 0;
+  display: inline-block;
+  border-top: 15px solid var(--theme-primary);
+  border-bottom: 15px solid var(--theme-secondary);
+  border-right: 0;
+  border-left: 0;
+  padding: 0;
+  box-shadow: 0 0 3px gray;
+}
+
+.submit-color-button:hover {
+  box-shadow: 2px 2px 2px gray;
+}
+
+.submit-color-button.active {
+  box-shadow: 3px 3px 3px gray;
 }

--- a/app/static/cubic-orchard.jpg.license
+++ b/app/static/cubic-orchard.jpg.license
@@ -1,3 +1,3 @@
-SPDX-FileCopyrightText: 2022 Aurelie Herbelot, <aurelie.herbelot@unitn.it>, 
+SPDX-FileCopyrightText: 2022 PeARS Project, <community@pearsproject.org>, 
 
 SPDX-License-Identifier: AGPL-3.0-only

--- a/app/static/example_snow_pod.png.license
+++ b/app/static/example_snow_pod.png.license
@@ -1,3 +1,3 @@
-SPDX-FileCopyrightText: 2022 Aurelie Herbelot, <aurelie.herbelot@unitn.it>, 
+SPDX-FileCopyrightText: 2022 PeARS Project, <community@pearsproject.org>, 
 
 SPDX-License-Identifier: AGPL-3.0-only

--- a/app/static/favicon.png.license
+++ b/app/static/favicon.png.license
@@ -1,3 +1,3 @@
-SPDX-FileCopyrightText: 2022 Aurelie Herbelot, <aurelie.herbelot@unitn.it>, 
+SPDX-FileCopyrightText: 2022 PeARS Project, <community@pearsproject.org>, 
 
 SPDX-License-Identifier: AGPL-3.0-only

--- a/app/static/header-small.jpg.license
+++ b/app/static/header-small.jpg.license
@@ -1,3 +1,3 @@
-SPDX-FileCopyrightText: 2022 Aurelie Herbelot, <aurelie.herbelot@unitn.it>, 
+SPDX-FileCopyrightText: 2022 PeARS Project, <community@pearsproject.org>, 
 
 SPDX-License-Identifier: AGPL-3.0-only

--- a/app/static/js/color.js
+++ b/app/static/js/color.js
@@ -1,3 +1,7 @@
+//SPDX-FileCopyrightText: 2022 PeARS Project, <community@pearsproject.org>, 
+//SPDX-License-Identifier: AGPL-3.0-only
+
+
 function initColor() {
   localPrimaryColor = localStorage.getItem("--primary-color")
   if (localPrimaryColor != null) {

--- a/app/static/js/color.js
+++ b/app/static/js/color.js
@@ -1,0 +1,28 @@
+function initColor() {
+  localPrimaryColor = localStorage.getItem("--primary-color")
+  if (localPrimaryColor != null) {
+    document.body.style.setProperty("--primary-color", localPrimaryColor);
+  }
+
+  localSecondaryColor = localStorage.getItem("--secondary-color")
+  if (localSecondaryColor != null) {
+    document.body.style.setProperty("--secondary-color", localSecondaryColor);
+  }
+}
+
+function changeColor() {
+  const target = event.target;
+  var primaryColor = getComputedStyle(target).getPropertyValue("--theme-primary");
+  var secondaryColor = getComputedStyle(target).getPropertyValue("--theme-secondary");
+  colors.forEach((color) => color.classList.remove("active"));
+  target.classList.add("active");
+  document.body.style.setProperty("--primary-color", primaryColor);
+  localStorage.setItem("--primary-color", primaryColor);
+  localStorage.setItem("--secondary-color", secondaryColor);
+  initColor()
+}
+
+initColor()
+const colors = document.querySelectorAll(".submit-color-button");
+colors.forEach((color) => color.addEventListener("click", changeColor));
+

--- a/app/static/pears-logo-green.png.license
+++ b/app/static/pears-logo-green.png.license
@@ -1,3 +1,3 @@
-SPDX-FileCopyrightText: 2022 Aurelie Herbelot, <aurelie.herbelot@unitn.it>, 
+SPDX-FileCopyrightText: 2022 PeARS Project, <community@pearsproject.org>, 
 
 SPDX-License-Identifier: AGPL-3.0-only

--- a/app/static/pears-logo-small.png.license
+++ b/app/static/pears-logo-small.png.license
@@ -1,3 +1,3 @@
-SPDX-FileCopyrightText: 2022 Aurelie Herbelot, <aurelie.herbelot@unitn.it>, 
+SPDX-FileCopyrightText: 2022 PeARS Project, <community@pearsproject.org>, 
 
 SPDX-License-Identifier: AGPL-3.0-only

--- a/app/static/pears-logo.png.license
+++ b/app/static/pears-logo.png.license
@@ -1,3 +1,3 @@
-SPDX-FileCopyrightText: 2022 Aurelie Herbelot, <aurelie.herbelot@unitn.it>, 
+SPDX-FileCopyrightText: 2022 PeARS Project, <community@pearsproject.org>, 
 
 SPDX-License-Identifier: AGPL-3.0-only

--- a/app/static/pears-offline.png.license
+++ b/app/static/pears-offline.png.license
@@ -1,3 +1,3 @@
-SPDX-FileCopyrightText: 2022 Aurelie Herbelot, <aurelie.herbelot@unitn.it>, 
+SPDX-FileCopyrightText: 2022 PeARS Project, <community@pearsproject.org>, 
 
 SPDX-License-Identifier: AGPL-3.0-only

--- a/app/static/pears_round.png.license
+++ b/app/static/pears_round.png.license
@@ -1,3 +1,3 @@
-SPDX-FileCopyrightText: 2022 Aurelie Herbelot, <aurelie.herbelot@unitn.it>, 
+SPDX-FileCopyrightText: 2022 PeARS Project, <community@pearsproject.org>, 
 
 SPDX-License-Identifier: AGPL-3.0-only

--- a/app/static/pi-pic.png.license
+++ b/app/static/pi-pic.png.license
@@ -1,3 +1,3 @@
-SPDX-FileCopyrightText: 2022 Aurelie Herbelot, <aurelie.herbelot@unitn.it>, 
+SPDX-FileCopyrightText: 2022 PeARS Project, <community@pearsproject.org>, 
 
 SPDX-License-Identifier: AGPL-3.0-only

--- a/app/static/pods/README.md
+++ b/app/static/pods/README.md
@@ -1,5 +1,5 @@
 <!--
-SPDX-FileCopyrightText: 2022 Aurelie Herbelot, <aurelie.herbelot@unitn.it>, 
+SPDX-FileCopyrightText: 2022 PeARS Project, <community@pearsproject.org>, 
 
 SPDX-License-Identifier: AGPL-3.0-only
 -->

--- a/app/static/tree-silhouette.png.license
+++ b/app/static/tree-silhouette.png.license
@@ -1,3 +1,3 @@
-SPDX-FileCopyrightText: 2022 Aurelie Herbelot, <aurelie.herbelot@unitn.it>, 
+SPDX-FileCopyrightText: 2022 PeARS Project, <community@pearsproject.org>, 
 
 SPDX-License-Identifier: AGPL-3.0-only

--- a/app/templates/admin/pears_list.html
+++ b/app/templates/admin/pears_list.html
@@ -1,5 +1,5 @@
 <!--
-SPDX-FileCopyrightText: 2022 Aurelie Herbelot, <aurelie.herbelot@unitn.it>, 
+SPDX-FileCopyrightText: 2022 PeARS Project, <community@pearsproject.org>, 
 
 SPDX-License-Identifier: AGPL-3.0-only
 -->

--- a/app/templates/base/base.html
+++ b/app/templates/base/base.html
@@ -21,7 +21,7 @@ SPDX-License-Identifier: AGPL-3.0-only
 
 <body>
 {% block navbar %}
-<nav class="navbar navbar-expand-lg navbar-light" style="background-color: #5DD39E;">
+<nav class="navbar navbar-expand-lg navbar-light">
     <div class="container">
         <a class="navbar-brand mx-auto" href="{{url_for('search.index')}}"><img src="{{ url_for('static', filename='pears_round.png')}}" height="50px"> PeARS</a>
         {% block navbar_toggler %}
@@ -47,6 +47,7 @@ SPDX-License-Identifier: AGPL-3.0-only
                 <li class="nav-item"><a class="nav-link" href="{{url_for('admin.index')}}">DB admin</a></li>          
             </ul>
             <ul class="nav navbar-nav navbar-right">
+                <li class="nav-item"><a class="nav-link" href="{{url_for('settings.index')}}">Settings</a></li>
                 <li class="nav-item"><a class="nav-link" href="{{url_for('pages.return_faq')}}">F.A.Q.</a></li>
                 <li class="nav-item"><a class="nav-link" href="{{url_for('pages.return_acknowledgements')}}">Acknowledgments</a>
                 </li>
@@ -88,8 +89,9 @@ SPDX-License-Identifier: AGPL-3.0-only
         {% block body %}{% endblock %}
     </div>
 <!-- script references -->
-<script src="//ajax.googleapis.com/ajax/libs/jquery/2.0.2/jquery.min.js"></script>
+<script src="https://ajax.googleapis.com/ajax/libs/jquery/3.3.1/jquery.min.js"></script>
 <script src="{{ url_for('static', filename='js/bootstrap/bootstrap.min.js')}}"></script>
+<script src="{{ url_for('static', filename='js/color.js')}}"></script>
 </body>
 
 </html>

--- a/app/templates/indexer/progress1.html
+++ b/app/templates/indexer/progress1.html
@@ -1,5 +1,5 @@
 <!--
-SPDX-FileCopyrightText: 2022 Aurelie Herbelot, <aurelie.herbelot@unitn.it>, 
+SPDX-FileCopyrightText: 2022 PeARS Project, <community@pearsproject.org>, 
 
 SPDX-License-Identifier: AGPL-3.0-only
 -->

--- a/app/templates/indexer/progress2.html
+++ b/app/templates/indexer/progress2.html
@@ -1,5 +1,5 @@
 <!--
-SPDX-FileCopyrightText: 2022 Aurelie Herbelot, <aurelie.herbelot@unitn.it>, 
+SPDX-FileCopyrightText: 2022 PeARS Project, <community@pearsproject.org>, 
 
 SPDX-License-Identifier: AGPL-3.0-only
 -->

--- a/app/templates/indexer/progress3.html
+++ b/app/templates/indexer/progress3.html
@@ -1,5 +1,5 @@
 <!--
-SPDX-FileCopyrightText: 2022 Aurelie Herbelot, <aurelie.herbelot@unitn.it>, 
+SPDX-FileCopyrightText: 2022 PeARS Project, <community@pearsproject.org>, 
 
 SPDX-License-Identifier: AGPL-3.0-only
 -->

--- a/app/templates/indexer/progress_crawl.html
+++ b/app/templates/indexer/progress_crawl.html
@@ -1,5 +1,5 @@
 <!--
-SPDX-FileCopyrightText: 2022 Aurelie Herbelot, <aurelie.herbelot@unitn.it>, 
+SPDX-FileCopyrightText: 2022 PeARS Project, <community@pearsproject.org>, 
 
 SPDX-License-Identifier: AGPL-3.0-only
 -->

--- a/app/templates/indexer/progress_file.html
+++ b/app/templates/indexer/progress_file.html
@@ -1,5 +1,5 @@
 <!--
-SPDX-FileCopyrightText: 2022 Aurelie Herbelot, <aurelie.herbelot@unitn.it>, 
+SPDX-FileCopyrightText: 2022 PeARS Project, <community@pearsproject.org>, 
 
 SPDX-License-Identifier: AGPL-3.0-only
 -->

--- a/app/templates/indexer/progress_url.html
+++ b/app/templates/indexer/progress_url.html
@@ -1,5 +1,5 @@
 <!--
-SPDX-FileCopyrightText: 2022 Aurelie Herbelot, <aurelie.herbelot@unitn.it>, 
+SPDX-FileCopyrightText: 2022 PeARS Project, <community@pearsproject.org>, 
 
 SPDX-License-Identifier: AGPL-3.0-only
 -->

--- a/app/templates/pod_finder/progress_file.html
+++ b/app/templates/pod_finder/progress_file.html
@@ -1,5 +1,5 @@
 <!--
-SPDX-FileCopyrightText: 2022 Aurelie Herbelot, <aurelie.herbelot@unitn.it>, 
+SPDX-FileCopyrightText: 2022 PeARS Project, <community@pearsproject.org>, 
 
 SPDX-License-Identifier: AGPL-3.0-only
 -->

--- a/app/templates/pod_finder/progress_pod.html
+++ b/app/templates/pod_finder/progress_pod.html
@@ -1,5 +1,5 @@
 <!--
-SPDX-FileCopyrightText: 2022 Aurelie Herbelot, <aurelie.herbelot@unitn.it>, 
+SPDX-FileCopyrightText: 2022 PeARS Project, <community@pearsproject.org>, 
 
 SPDX-License-Identifier: AGPL-3.0-only
 -->

--- a/app/templates/pod_finder/progress_pod_update.html
+++ b/app/templates/pod_finder/progress_pod_update.html
@@ -1,5 +1,5 @@
 <!--
-SPDX-FileCopyrightText: 2022 Aurelie Herbelot, <aurelie.herbelot@unitn.it>, 
+SPDX-FileCopyrightText: 2022 PeARS Project, <community@pearsproject.org>, 
 
 SPDX-License-Identifier: AGPL-3.0-only
 -->

--- a/app/templates/pod_finder/search-box.html
+++ b/app/templates/pod_finder/search-box.html
@@ -1,5 +1,5 @@
 <!--
-SPDX-FileCopyrightText: 2022 Aurelie Herbelot, <aurelie.herbelot@unitn.it>, 
+SPDX-FileCopyrightText: 2022 PeARS Project, <community@pearsproject.org>, 
 
 SPDX-License-Identifier: AGPL-3.0-only
 -->

--- a/app/templates/search/index.html
+++ b/app/templates/search/index.html
@@ -13,7 +13,7 @@ SPDX-License-Identifier: AGPL-3.0-only
       <form  action="{{url_for('.index')}}">
         <div class="input-group group mt-4" >
           <input class="form-control" title="Enter your Search Query." placeholder="Enter your Search Query" type="search" name='q' required>
-          <button class="btn btn-lg btn-outline-success" type="submit">Search</button>
+          <button class="btn btn-lg btn-success" type="submit">Search</button>
         </div>
       </form>
     </div>

--- a/app/templates/settings/index.html
+++ b/app/templates/settings/index.html
@@ -1,0 +1,41 @@
+<!--
+SPDX-FileCopyrightText: 2022 PeARS Project, <community@pearsproject.org>, 
+
+SPDX-License-Identifier: AGPL-3.0-only
+-->
+
+{% extends "base/base.html" %}
+{% block body %}
+<div class="container">
+
+  <div class="row p-3">
+    <div class="col-md-6">
+      <div class="card">
+        <div class="card-header text-center"><b>Color scheme</b></div>
+          <div class="card-body">
+          <p>Change your color scheme.</p>
+	    <button type="button" class="submit-color-button active" style="--theme-primary:orange; --theme-secondary:green;" id="blue"></button>
+            <button type="button" class="submit-color-button" style="--theme-primary:#2196F3; --theme-secondary:black;" id="green"></button>
+        </div>
+      </div>
+    </div>
+
+    <div class="col-md-6">
+      <div class="card">
+        <div class="card-header text-center"><b>Install languages</b></div>
+        <div class="card-body">
+          <p>Install the languages you would like to use in PeARS.</p>
+
+        </div>
+        <div class="card-footer clearfix">
+          <span class="input-group-btn float-end">
+            <input id="submit_button" type="submit" class="btn btn-success" value="Install">
+          </span>
+        </div>
+        </form>
+      </div>
+    </div>
+  </div>
+
+</div><!-- /.container -->
+{% endblock %}

--- a/app/templates/settings/index.html
+++ b/app/templates/settings/index.html
@@ -13,23 +13,27 @@ SPDX-License-Identifier: AGPL-3.0-only
       <div class="card">
         <div class="card-header text-center"><b>Color scheme</b></div>
           <div class="card-body">
-          <p>Change your color scheme.</p>
-	    <button type="button" class="submit-color-button active" style="--theme-primary:orange; --theme-secondary:green;" id="blue"></button>
-            <button type="button" class="submit-color-button" style="--theme-primary:#2196F3; --theme-secondary:black;" id="green"></button>
+          <p>Change your color scheme by clicking on the options below.</p>
+            <button type="button" class="submit-color-button active" style="--theme-primary:#2196F3; --theme-secondary:black;" id="blue"></button>
+	    <button type="button" class="submit-color-button" style="--theme-primary:orange; --theme-secondary:green;" id="orange"></button>
+            <button type="button" class="submit-color-button" style="--theme-primary:#038B30; --theme-secondary:#013D15;" id="green"></button>
+            <button type="button" class="submit-color-button" style="--theme-primary:#A16AE8; --theme-secondary:#BEAFC2;" id="purple"></button>
+	  </div>
+          <div class="card-footer clearfix" style="height:38px">
+	  </div>
         </div>
-      </div>
     </div>
 
     <div class="col-md-6">
       <div class="card">
         <div class="card-header text-center"><b>Install languages</b></div>
         <div class="card-body">
-          <p>Install the languages you would like to use in PeARS.</p>
+          <p>You will soon be able to install new languages for your PeARS, right here. Stay tuned!</p>
 
         </div>
         <div class="card-footer clearfix">
           <span class="input-group-btn float-end">
-            <input id="submit_button" type="submit" class="btn btn-success" value="Install">
+            <input id="submit_button" type="submit" class="btn btn-success" value="Coming soon">
           </span>
         </div>
         </form>


### PR DESCRIPTION
This fixes the licence headers for all .py, .html and .png.license files. The only remaining license issues concern the pretrained models for the fruit fly, which (following advice from the FSF) should probably be under a CC license. I will open a separate PR for those.