### PR TITLE
Update the application bind address in for fruitfly-api

### DIFF
--- a/run.py
+++ b/run.py
@@ -14,4 +14,4 @@ class DeployedFly:
         self.hyperparameters = None
 
 from app import app
-app.run(host='localhost', port=8080, debug=True)
+app.run(host='0.0.0.0', port=8080, debug=True)


### PR DESCRIPTION
For the ease of use of the app, I am trying to use the docker image of `orchard` from DHT repo, but if the binding address is not `0.0.0.0` it would hard to access the server from the host machine. This PR fixes it